### PR TITLE
Update the runtime of the website helper Lambda from python 3.6 to 3.9.

### DIFF
--- a/deployment/content-localization-on-aws-web.yaml
+++ b/deployment/content-localization-on-aws-web.yaml
@@ -290,7 +290,7 @@ Resources:
       Handler: website_helper.lambda_handler
       MemorySize: 256
       Role: !GetAtt WebsiteHelperRole.Arn
-      Runtime: python3.6
+      Runtime: python3.9
       Timeout: 900
       Environment:
         Variables:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Update the runtime of the website helper Lambda from python 3.6 to 3.9 as the former will no longer receive security and other updates as of July 18th 2022.

Announcement shared via personal AWS health dashboard.
"[...] Starting July 18, 2022, Lambda will no longer apply security patches and other updates to the Python 3.6 runtime. [...] Starting August 17, 2022, you will no longer be able to update existing functions using the Python 3.6 runtime. We recommend that you upgrade your existing Python 3.6 functions to Python 3.9 before August 17, 2022."

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
