### PR TITLE
Bump versions for new pipeline

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -8,8 +8,8 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      nodejs: 12
-      python: 3.8
+      nodejs: 16
+      python: 3.10
     commands:
       - echo "nothing to do in install"
   pre_build:

--- a/test/e2e/requirements.txt
+++ b/test/e2e/requirements.txt
@@ -1,6 +1,6 @@
 pytest==7.2.0
 requests==2.28.1
-requests_aws4auth==1.1.1
+requests-aws4auth~=1.2.0
 webdriver-manager==3.4.2
 selenium==3.141.0
 boto3==1.26.17


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Bump runtime and package versions to support new pipeline:

* nodejs from 12 to 16
* python from 3.8 to 3.10
* requests-aws4auth from 1.1 to 1.2

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
