### PR TITLE
Fix upload of WebVTT files

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -43,7 +43,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -54,7 +54,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * The "Download Data" button on the **Celebrities** works now.
+* Fixed upload of WebVTT files as "Existing Subtitles".
 
 ## [2.0.2] - 2023-01-11
 

--- a/source/website/src/views/UploadToAWSS3.vue
+++ b/source/website/src/views/UploadToAWSS3.vue
@@ -906,7 +906,7 @@ export default {
     {
       let errorMessage = '';
       console.log(file.type)
-      if (!(file.type).match(/video\/.+|application\/mxf/g)) {
+      if (!(file.type).match(/video\/.+|application\/mxf|text\/vtt/g)) {
         if (file.type === "")
           errorMessage = "Unsupported file type: unknown";
         else
@@ -924,7 +924,7 @@ export default {
     fileRemoved: function( file )
     {
       let errorMessage = '';
-      if (!(file.type).match(/video\/.+|application\/mxf/g)) {
+      if (!(file.type).match(/video\/.+|application\/mxf|text\/vtt/g)) {
         if (file.type === "")
           errorMessage = "Unsupported file type: unknown";
         else
@@ -997,10 +997,17 @@ export default {
             this.workflow_config.Configuration.WebCaptions.WebCaptions.ExistingSubtitlesObject.Bucket=this.DATAPLANE_BUCKET
             this.workflow_config.Configuration.WebCaptions.WebCaptions.ExistingSubtitlesObject.Key=this.existingSubtitlesFilename
           }
-        } else if (media_type === '' && (s3Key.split('.').pop().toLowerCase() === 'vtt')) {
+        } else if ((media_type === '' || media_type === 'text/vtt') && (s3Key.split('.').pop().toLowerCase() === 'vtt')) {
           // VTT files may be uploaded for the Transcribe operator, but
           // we won't run a workflow for VTT file types.
           console.log("VTT file has been uploaded to s3://" + s3Key);
+          // We need the existingSubtitlesFilename to contain the full S3 key.
+          // If it was auto-populated when we added the WebVTT file for upload,
+          // existingSubtitlesFilename will only contain the file name but not
+          // the full key. So, rewrite it now that we know the full S3 key.
+          if (this.existingSubtitlesFilename === s3Key.split('/').pop()) {
+            this.existingSubtitlesFilename = s3Key;
+          }
           return;
         } else {
           vm.s3UploadError("Unsupported media type: " + media_type + ".");


### PR DESCRIPTION
Background
==========

The **Upload Content** page contains an input box for uploading media files and a text box to name a WebVTT file to use. It should allow the WebVTT file to be uploaded and the text box should be automatically populated with the name of the file. However, attempting to do so resulted in an error stating the following:

> Unsupported file type: text/vtt

Change
======

This change fixes the issue. Now a user can select a WebVTT file. No error is reported and the **Use Existing Subtitles** text box gets automatically populated with the name of the WebVTT file.

Selecting "Upload and Run Workflow" causes the files to successfully upload and the workflow begins to run.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
