### PR TITLE
Updated object ownership for website bucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.3] - 04/17/2023
+
+### Fixed:
+
+* Updated object ownership configuration on ContentAnalysisWebsiteBucket
+
 ## [2.0.2] - 01/11/2023
 
 ### Fixed:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -8,7 +8,7 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      nodejs: 12
+      nodejs: 16
       python: 3.8
     commands:
       - echo "nothing to do in install"

--- a/deployment/content-localization-on-aws-web.yaml
+++ b/deployment/content-localization-on-aws-web.yaml
@@ -92,6 +92,9 @@ Resources:
     DeletionPolicy: Retain
     Properties:
       AccessControl: LogDeliveryWrite
+      OwnershipControls:
+        Rules:
+          - ObjectOwnership: ObjectWriter
       BucketName: !GetAtt GetWebsiteBucketName.Data
       BucketEncryption:
         ServerSideEncryptionConfiguration:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updated object ownership configuration for ContentAnalysisWebsiteBucket.
S3 requires object ownership not set to Bucket Owner Enforced when using ACLs.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
