### PR TITLE
Update S3 Object Ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
 ## [Unreleased]
 
 ### Added
@@ -18,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * The "Download Data" button on the **Celebrities** tab works now.
 * Fixed upload of WebVTT files as "Existing Subtitles".
 * Incorrect Cloudformation template in public bucket (#365)
+* Updated object ownership configuration on ContentAnalysisWebsiteBucket
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-
-## [Unreleased]
+## [2.1.0] - 2023-04-19
 
 ### Added
 
@@ -24,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * Removed Hawkeye scan from github actions (deprecated)
-* Upgrade Media Insights on AWS dependency to v5.1.0
+* Upgrade Media Insights on AWS dependency to v5.1.1
 * Refactored some code for maintainability
 * Updated e2e tests for bug fixes and compatibility with new Media Insights on AWS version
 * Updated references to "Media Insights Engine" to "Media Insights on AWS"

--- a/deployment/build-s3-dist.sh
+++ b/deployment/build-s3-dist.sh
@@ -129,7 +129,6 @@ msg "- Profile: ${profile}"
 
 echo ""
 sleep 3
-s3domain="s3.$region.amazonaws.com"
 
 # Check if region is supported:
 if [ "$region" != "us-east-1" ] &&

--- a/deployment/content-localization-on-aws-web.yaml
+++ b/deployment/content-localization-on-aws-web.yaml
@@ -92,6 +92,9 @@ Resources:
     DeletionPolicy: Retain
     Properties:
       AccessControl: LogDeliveryWrite
+      OwnershipControls:
+        Rules:
+          - ObjectOwnership: ObjectWriter
       BucketName: !GetAtt GetWebsiteBucketName.Data
       BucketEncryption:
         ServerSideEncryptionConfiguration:

--- a/deployment/content-localization-on-aws.yaml
+++ b/deployment/content-localization-on-aws.yaml
@@ -24,7 +24,7 @@ Conditions:
 Mappings:
   MediaInsights:
     Release:
-      Version: "v5.1.0"
+      Version: "v5.1.1"
   Application:
     SourceCode:
       GlobalS3Bucket: "%%GLOBAL_BUCKET_NAME%%"

--- a/deployment/sync-s3-dist.sh
+++ b/deployment/sync-s3-dist.sh
@@ -138,6 +138,8 @@ cd "$build_dir"/ || exit 1
 echo "Copying the prepared distribution to:"
 echo "s3://$global_bucket/content-localization-on-aws/$version/"
 echo "s3://${regional_bucket}-${region}/content-localization-on-aws/$version/"
+
+s3domain="s3.$region.amazonaws.com"
 set -x
 aws s3 sync $global_dist_dir s3://$global_bucket/content-localization-on-aws/$version/ $(if [ ! -z $profile ]; then echo "--profile $profile"; fi)
 aws s3 sync $regional_dist_dir s3://${regional_bucket}-${region}/content-localization-on-aws/$version/ $(if [ ! -z $profile ]; then echo "--profile $profile"; fi)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
S3 now requires object owner to be defined when using bucket ACL
- Set object owner on ContentAnalysisWebsiteBucket.
- Updated MI version to v5.1.1

Small change to sync script
- add s3 domain variable definition
- remove unused variable from build script

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
