### PR TITLE
Release v2.1.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 TODO: Update release date when time is known
 
+## [2.1.14] - 2025-06-04
+
+### Security
+
+- Updated `Media Insights on AWS` version to v5.1.11
+
 ## [2.1.13] - 2025-04-04
 
 ### Security

--- a/deployment/content-localization-on-aws.yaml
+++ b/deployment/content-localization-on-aws.yaml
@@ -24,7 +24,7 @@ Conditions:
 Mappings:
   MediaInsights:
     Release:
-      Version: "v5.1.10"
+      Version: "v5.1.11"
   Application:
     SourceCode:
       GlobalS3Bucket: "%%GLOBAL_BUCKET_NAME%%"

--- a/source/website/package-lock.json
+++ b/source/website/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "content-localization-on-aws",
-  "version": "2.1.13",
+  "version": "2.1.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "content-localization-on-aws",
-      "version": "2.1.13",
+      "version": "2.1.14",
       "license": "Apache-2.0",
       "dependencies": {
         "@vue/compat": "^3.4.21",

--- a/source/website/package.json
+++ b/source/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "content-localization-on-aws",
-  "version": "2.1.13",
+  "version": "2.1.14",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Release v2.1.14 of Content Localization On AWS

Changelog:
Updated `Media Insights on AWS` version to v5.1.11
